### PR TITLE
Add a maximum version of GDAL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
 install:
   - python -m pip install -U pip
   - pip install -U tox-travis
-  - conda install --yes gdal numba scipy tensorflow pytest
+  - conda install --yes gdal"<=2.5.2" numba scipy tensorflow pytest
 
 # Command to run tests, e.g. python setup.py test
 script: tox


### PR DESCRIPTION
Prevent conda from installing GDAL packages with major version number 3 or greater.